### PR TITLE
fix model_tokens not being used for ollama

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -174,8 +174,9 @@ class AbstractGraph(ABC):
 
             elif "ollama" in llm_params["model"]:
                 model_name = llm_params["model"].split("ollama/")[-1]
-                token_key = model_name if "model_tokens" not in llm_params else llm_params["model_tokens"]
-                return handle_model(model_name, "ollama", token_key)
+                token_key = model_name if "model_tokens" not in llm_params else None
+                explicit_model_tokens = 8192 if "model_tokens" not in llm_params else llm_params["model_tokens"]
+                return handle_model(model_name, "ollama", token_key, explicit_model_tokens)
 
             elif "claude-3-" in llm_params["model"]:
                 return handle_model(llm_params["model"], "anthropic", "claude3")


### PR DESCRIPTION
I am passing in the explicit model_tokens from user config as the default_token so it will correctly fallback to the users setting if the model is not found